### PR TITLE
Add support for Alexa locale configuration

### DIFF
--- a/source/_integrations/alexa.smart_home.markdown
+++ b/source/_integrations/alexa.smart_home.markdown
@@ -207,6 +207,7 @@ Example configuration:
 ```yaml
 alexa:
   smart_home:
+    locale: en-US
     endpoint: https://api.amazonalexa.com/v3/events
     client_id: !secret alexa_client_id
     client_secret: !secret alexa_client_secret
@@ -225,6 +226,8 @@ alexa:
       switch.stairs:
         display_categories: LIGHT
 ```
+
+Set the `locale` to the locale of your Alexa devices. Supported locales are: `de-DE`,  `en-AU`, `en-CA`, `en-GB`, `en-IN`, `en-US`, `es-ES`, `es-MX`, `fr-CA`, `fr-FR`, `it-IT`, `ja-JP`. Default is `en-US`.
 
 The `endpoint`, `client_id` and `client_secret` are optional, and are only required if you want to enable Alexa's proactive mode (i.e. "Send Alexa Events" enabled). Please note the following if you want to enable proactive mode:
 


### PR DESCRIPTION
**Description:**
Document support for Alexa locale configuration setting.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant# (To be submitted)

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
